### PR TITLE
Fix local development: database creation and seed execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,6 @@ npx degit https://github.com/cameronapak/freedom-stack-v2 my-project
 
 ## Setup
 
-### Create User
-
-This may look funny, but running bknd this way makes it where bknd will use our `bknd.config.ts` file.
-
-```bash
-npx tsx node_modules/.bin/bknd user create
-```
-
-### Run App
-
 Using Node Version Manager?
 
 ```bash
@@ -73,13 +63,21 @@ nvm use
 Install the packages.
 
 ```bash
-npm install
+bun install
+```
+
+### Create User
+
+Create your first user (this runs bknd with our `bknd.config.ts` file):
+
+```bash
+npx tsx node_modules/.bin/bknd user create
 ```
 
 Now, let's run the app!
 
 ```bash
-npm run dev
+bun dev
 ```
 
 ## Main changes since v1

--- a/bknd.config.ts
+++ b/bknd.config.ts
@@ -35,13 +35,17 @@ const config = {
   app: (_ctx: APIContext) => ({
     connection:
       !!process.env.LIBSQL_DATABASE_URL && !!process.env.LIBSQL_DATABASE_TOKEN
-        ? libsql({
-            url: process.env.LIBSQL_DATABASE_URL,
-            authToken: process.env.DB_LIBSQL_TOKEN
-          })
-        : {
-            url: "file:.astro/content.db"
-          }
+        ? libsql(
+            createClient({
+              url: process.env.LIBSQL_DATABASE_URL,
+              authToken: process.env.DB_LIBSQL_TOKEN
+            })
+          )
+        : libsql(
+            createClient({
+              url: "file:.astro/content.db"
+            })
+          )
   }),
   // an initial config is only applied if the database is empty
   config: {


### PR DESCRIPTION
Fixes #12

## Problem

First run fails with "unable to open database file" because local connection doesn't use `createClient()`.

## Fix

**bknd.config.ts:**
```diff
-        : {
-            url: "file:.astro/content.db"
-          }
+        : libsql(
+            createClient({
+              url: "file:.astro/content.db"
+            })
+          )
```

**README.md:**
- Use `bun` instead of `npm` (matches bun.lock)
- Minor reordering of setup steps

## Testing

1. `bun install`
2. `npx tsx node_modules/.bin/bknd user create`
3. `bun dev`
4. Login works